### PR TITLE
make height of select bar larger than font size

### DIFF
--- a/showcase/main.css
+++ b/showcase/main.css
@@ -98,7 +98,7 @@ select {
 	display: flex;
 	font-size: 10px;
 	font-weight: 700;
-  height: 10px;
+  height: 15px;
   margin: 0;
   text-transform: uppercase;
   text-align-last: right;


### PR DESCRIPTION
Before:

![select-before](https://user-images.githubusercontent.com/338833/201429564-186130ff-71f7-4361-99a7-51592619431c.png)

After:
![select-after](https://user-images.githubusercontent.com/338833/201429561-291ba562-8d9f-45eb-b979-a97d5659a901.png)

